### PR TITLE
Set sink after setting source

### DIFF
--- a/demo/rnnoise.js
+++ b/demo/rnnoise.js
@@ -46,8 +46,8 @@ if (navigator.mediaDevices &&
                         }) : context.destination;
                         if (sink) {
                             const audio = new Audio();
-                            audio.setSinkId(output.value);
                             audio.srcObject = destination.stream;
+                            audio.setSinkId(output.value);
                             audio.play();
                         }
                         const [stream] = await Promise.all([


### PR DESCRIPTION
Somehow this change is required to select the output device in the latest version of Chrome / Edge.